### PR TITLE
Fix error on LispWorks

### DIFF
--- a/fallback.lisp
+++ b/fallback.lisp
@@ -1,6 +1,6 @@
 (defpackage #:org.shirakumo.trivial-extensible-sequences.fallback
   (:use #:cl)
-  #+(or abcl ccl clasp ecl sbcl)
+  #+(or abcl ccl clasp ecl sbcl lispworks8)
   (:local-nicknames (#:sequences #:org.shirakumo.trivial-extensible-sequences))
   (:shadow #:step #:endp))
 (in-package #:org.shirakumo.trivial-extensible-sequences.fallback)


### PR DESCRIPTION
Since Lispworks 8.0.1 it has [added package-local nickname support](https://www.lispworks.com/documentation/lw80/rnig/rnig-release80-7.htm), it can run on lispworks now (。